### PR TITLE
Skip loading outlines when the outline root node is invalid

### DIFF
--- a/model/reader.go
+++ b/model/reader.go
@@ -283,7 +283,8 @@ func (r *PdfReader) loadOutlines() (*PdfOutlineTreeNode, error) {
 	outlineRoot, ok := outlineRootObj.(*core.PdfIndirectObject)
 	if !ok {
 		if _, ok := core.GetDict(outlineRootObj); !ok {
-			return nil, errors.New("outline root should be an indirect object")
+			common.Log.Debug("Invalid outline root - skipping")
+			return nil, nil
 		}
 
 		common.Log.Debug("Outline root is a dict. Should be an indirect object")


### PR DESCRIPTION
Addresses #57

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unipdf/84)
<!-- Reviewable:end -->
