### PR TITLE
Parse EOF markers missing the F character

### DIFF
--- a/core/parser.go
+++ b/core/parser.go
@@ -24,7 +24,7 @@ import (
 
 // Regular Expressions for parsing and identifying object signatures.
 var rePdfVersion = regexp.MustCompile(`%PDF-(\d)\.(\d)`)
-var reEOF = regexp.MustCompile("%%EOF")
+var reEOF = regexp.MustCompile("%%EOF?")
 var reXrefTable = regexp.MustCompile(`\s*xref\s*`)
 var reStartXref = regexp.MustCompile(`startx?ref\s*(\d+)`)
 var reNumeric = regexp.MustCompile(`^[\+-.]*([0-9.]+)`)


### PR DESCRIPTION
Addresses #64

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unipdf/86)
<!-- Reviewable:end -->
