### PR TITLE
Fixed CalRGB -> RGB image conversion.

### DIFF
--- a/model/colorspace.go
+++ b/model/colorspace.go
@@ -1298,7 +1298,7 @@ func (cs *PdfColorspaceCalRGB) ImageToRGB(img Image) (Image, error) {
 	maxVal := math.Pow(2, float64(img.BitsPerComponent)) - 1
 
 	var rgbSamples []uint32
-	for i := 0; i < len(samples)-2; i++ {
+	for i := 0; i < len(samples)-2; i += 3 {
 		// A, B, C in range 0.0 to 1.0
 		aVal := float64(samples[i]) / maxVal
 		bVal := float64(samples[i+1]) / maxVal


### PR DESCRIPTION
Fixed what was probably a typo. We noticed this when doing grayscale conversion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unipdf/103)
<!-- Reviewable:end -->
