### PR TITLE
Resolve references of page parent nodes when adding page to writer

### DIFF
--- a/model/writer.go
+++ b/model/writer.go
@@ -584,7 +584,7 @@ func (w *PdfWriter) AddPage(page *PdfPage) error {
 
 	// Copy inherited fields if missing.
 	inheritedFields := []core.PdfObjectName{"Resources", "MediaBox", "CropBox", "Rotate"}
-	parent, hasParent := pDict.Get("Parent").(*core.PdfIndirectObject)
+	parent, hasParent := core.GetIndirect(pDict.Get("Parent"))
 	common.Log.Trace("Page Parent: %T (%v)", pDict.Get("Parent"), hasParent)
 	for hasParent {
 		common.Log.Trace("Page Parent: %T", parent)


### PR DESCRIPTION
Necessary when adding pages to a writer using a lazy reader. Parent object references need to be resolved in order to access the inheritable fields.

Addresses #105

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unipdf/110)
<!-- Reviewable:end -->
