### PR TITLE
Avoid unnecessary allocations when converting gray scale image to RGB

### DIFF
--- a/model/colorspace.go
+++ b/model/colorspace.go
@@ -309,10 +309,12 @@ func (cs *PdfColorspaceDeviceGray) ImageToRGB(img Image) (Image, error) {
 	samples := img.GetSamples()
 	common.Log.Trace("DeviceGray-ToRGB Samples: % d", samples)
 
-	var rgbSamples []uint32
-	for i := 0; i < len(samples); i++ {
+	lenSamples := len(samples)
+	rgbSamples := make([]uint32, 3*lenSamples)
+
+	for i := 0; i < lenSamples; i++ {
 		grayVal := samples[i] * 255 / uint32(math.Pow(2, float64(img.BitsPerComponent))-1)
-		rgbSamples = append(rgbSamples, grayVal, grayVal, grayVal)
+		rgbSamples[3*i], rgbSamples[3*i+1], rgbSamples[3*i+2] = grayVal, grayVal, grayVal
 	}
 
 	rgbImage.BitsPerComponent = 8


### PR DESCRIPTION
Related to #7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unipdf/117)
<!-- Reviewable:end -->
