### PR TITLE
Table styled paragraph links

### DIFF
--- a/creator/block.go
+++ b/creator/block.go
@@ -343,8 +343,7 @@ func (blk *Block) Draw(d Drawable) error {
 	}
 
 	for _, newBlock := range blocks {
-		err := mergeContents(blk.contents, blk.resources, newBlock.contents, newBlock.resources)
-		if err != nil {
+		if err := blk.mergeBlocks(newBlock); err != nil {
 			return err
 		}
 	}
@@ -364,8 +363,7 @@ func (blk *Block) DrawWithContext(d Drawable, ctx DrawContext) error {
 	}
 
 	for _, newBlock := range blocks {
-		err := mergeContents(blk.contents, blk.resources, newBlock.contents, newBlock.resources)
-		if err != nil {
+		if err := blk.mergeBlocks(newBlock); err != nil {
 			return err
 		}
 	}

--- a/creator/table_test.go
+++ b/creator/table_test.go
@@ -525,3 +525,55 @@ func TestTableSubtables(t *testing.T) {
 		t.Fatalf("Fail: %v\n", err)
 	}
 }
+
+func TestTableParagraphLinks(t *testing.T) {
+	c := New()
+
+	// First page.
+	c.NewPage()
+	table := c.NewTable(2)
+
+	// Add internal link cells.
+	cell := table.NewCell()
+	cell.SetBorder(CellBorderSideAll, CellBorderStyleSingle, 1)
+	p := c.NewStyledParagraph()
+	p.Append("Internal link")
+	cell.SetContent(p)
+
+	cell = table.NewCell()
+	cell.SetBorder(CellBorderSideAll, CellBorderStyleSingle, 1)
+	p = c.NewStyledParagraph()
+	p.AddInternalLink("link to second page", 2, 0, 0, 0)
+	cell.SetContent(p)
+
+	// Add external link cells.
+	cell = table.NewCell()
+	cell.SetBorder(CellBorderSideAll, CellBorderStyleSingle, 1)
+	p = c.NewStyledParagraph()
+	p.Append("External link")
+	cell.SetContent(p)
+
+	cell = table.NewCell()
+	cell.SetBorder(CellBorderSideAll, CellBorderStyleSingle, 1)
+	p = c.NewStyledParagraph()
+	p.AddExternalLink("link to UniPDF", "https://github.com/unidoc/unipdf")
+	cell.SetContent(p)
+
+	if err := c.Draw(table); err != nil {
+		t.Fatalf("Error drawing: %v", err)
+	}
+
+	// Second page.
+	c.NewPage()
+
+	p = c.NewStyledParagraph()
+	p.Append("Page 2").Style.FontSize = 24
+
+	if err := c.Draw(p); err != nil {
+		t.Fatalf("Error drawing: %v", err)
+	}
+
+	if err := c.WriteToFile(tempFile("table_paragraph_links.pdf")); err != nil {
+		t.Fatalf("Fail: %v\n", err)
+	}
+}


### PR DESCRIPTION
Fix styled paragraph link annotations not present when the paragraph is part of a table.

Addresses #137

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unipdf/138)
<!-- Reviewable:end -->
