### PR TITLE
Append function to TextMarkArray for processing and grouping text

### DIFF
--- a/common/license/util.go
+++ b/common/license/util.go
@@ -8,10 +8,14 @@ package license
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"strings"
+
+	"github.com/unidoc/unipdf/v3/common"
 )
 
-// Defaults to the open source license.
+// Defaults to unlicensed.
 var licenseKey = MakeUnlicensedKey()
 
 // SetLicenseKey sets and validates the license key.
@@ -33,6 +37,29 @@ func SetLicenseKey(content string, customerName string) error {
 	licenseKey = &lk
 
 	return nil
+}
+
+const licensePathEnvironmentVar = `UNIPDF_LICENSE_PATH`
+const licenseCustomerNameEnvironmentVar = `UNIPDF_CUSTOMER_NAME`
+
+func init() {
+	lpath := os.Getenv(licensePathEnvironmentVar)
+	custName := os.Getenv(licenseCustomerNameEnvironmentVar)
+
+	if len(lpath) == 0 && len(custName) == 0 {
+		return
+	}
+
+	data, err := ioutil.ReadFile(lpath)
+	if err != nil {
+		common.Log.Debug("Unable to read license file: %v", err)
+		return
+	}
+	err = SetLicenseKey(string(data), custName)
+	if err != nil {
+		common.Log.Debug("Unable to load license: %v", err)
+		return
+	}
 }
 
 func GetLicenseKey() *LicenseKey {

--- a/common/license/util.go
+++ b/common/license/util.go
@@ -46,7 +46,7 @@ func init() {
 	lpath := os.Getenv(licensePathEnvironmentVar)
 	custName := os.Getenv(licenseCustomerNameEnvironmentVar)
 
-	if len(lpath) == 0 && len(custName) == 0 {
+	if len(lpath) == 0 || len(custName) == 0 {
 		return
 	}
 

--- a/extractor/text.go
+++ b/extractor/text.go
@@ -47,6 +47,8 @@ func (e *Extractor) ExtractPageText() (*PageText, int, int, error) {
 		return nil, numChars, numMisses, err
 	}
 	pt.computeViews()
+	procBuf(pt)
+
 	return pt, numChars, numMisses, err
 }
 
@@ -935,6 +937,11 @@ func (pt PageText) Marks() *TextMarkArray {
 // TextMarkArray is a collection of TextMarks.
 type TextMarkArray struct {
 	marks []TextMark
+}
+
+// Append appends `mark` to the mark array.
+func (ma *TextMarkArray) Append(mark TextMark) {
+	ma.marks = append(ma.marks, mark)
 }
 
 // String returns a string describing `ma`.

--- a/extractor/utils.go
+++ b/extractor/utils.go
@@ -54,7 +54,7 @@ func maxFloat(a, b float64) float64 {
 	return b
 }
 
-func procBuf(buf *bytes.Buffer) {
+func procBuf(pt *PageText) {
 	if isTesting {
 		return
 	}
@@ -66,12 +66,23 @@ func procBuf(buf *bytes.Buffer) {
 	fmt.Printf("Unlicensed copy of unidoc\n")
 	fmt.Printf("To get rid of the watermark and keep entire text - Please get a license on https://unidoc.io\n")
 
+	var buf bytes.Buffer
+	buf.WriteString(pt.viewText)
+
 	s := "- [Unlicensed UniDoc - Get a license on https://unidoc.io]"
 	if buf.Len() > 100 {
 		s = "... [Truncated - Unlicensed UniDoc - Get a license on https://unidoc.io]"
 		buf.Truncate(buf.Len() - 100)
 	}
 	buf.WriteString(s)
+	pt.viewText = buf.String()
+
+	if len(pt.marks) > 200 {
+		pt.marks = pt.marks[:200]
+	}
+	if len(pt.viewMarks) > 200 {
+		pt.viewMarks = pt.viewMarks[:200]
+	}
 }
 
 // truncate returns the first `n` characters in string `s`.


### PR DESCRIPTION
Adds `Append` to `TextMarkArray`. Necessary for pdf to csv tabular extraction example and great when processing and grouping text marks.

Also simplified license loading by supporting license loading via environment variables, setting
`UNIPDF_LICENSE_PATH` and `UNIPDF_CUSTOMER_NAME`  to a file containing the license key and customer name, e.g.
```
UNIPDF_CUSTOMER_NAME=UniDoc
UNIPDF_LICENSE_PATH=/path/to/licenses/UniDoc.txt
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unipdf/139)
<!-- Reviewable:end -->
