### PR TITLE
 Make PageText.sortPosition() sort order deterministic.

### DIFF
--- a/extractor/text.go
+++ b/extractor/text.go
@@ -1181,7 +1181,7 @@ var (
 // sortPosition sorts a text list by its elements' positions on a page.
 // Sorting is by orientation then top to bottom, left to right when page is orientated so that text
 // is horizontal.
-// Text is considered to be on different lines in orientedStart.Y differs by more than `tol`.
+// Text is considered to be on different lines if the lines' orientedStart.Y differs by more than `tol`.
 func (pt *PageText) sortPosition(tol float64) {
 	if len(pt.marks) == 0 {
 		return

--- a/extractor/text.go
+++ b/extractor/text.go
@@ -1192,7 +1192,7 @@ func (pt *PageText) sortPosition(tol float64) {
 		if ti.orient != tj.orient {
 			return ti.orient < tj.orient
 		}
-		return ti.orientedStart.Y > tj.orientedStart.Y
+		return ti.orientedStart.Y >= tj.orientedStart.Y
 	})
 
 	// Compute yOrder. yOrder increments if orientedStart.Y differs by more than `tol`.

--- a/extractor/text.go
+++ b/extractor/text.go
@@ -1223,6 +1223,22 @@ func (pt *PageText) sortPosition(tol float64) {
 	})
 }
 
+func (pt *PageText) sortPositionGus(tol float64) {
+	if len(pt.marks) == 0 {
+		return
+	}
+	sort.SliceStable(pt.marks, func(i, j int) bool {
+		ti, tj := pt.marks[i], pt.marks[j]
+		if ti.orient != tj.orient {
+			return ti.orient < tj.orient
+		}
+		if math.Abs(ti.orientedStart.Y-tj.orientedStart.Y) > tol {
+			return ti.orientedStart.Y >= tj.orientedStart.Y
+		}
+		return ti.orientedStart.X < tj.orientedStart.X
+	})
+
+}
 // textLine represents a line of text on a page.
 type textLine struct {
 	x      float64    // x position of line.

--- a/extractor/text_test.go
+++ b/extractor/text_test.go
@@ -57,7 +57,7 @@ func init() {
 }
 
 // TestTextExtractionFragments tests text extraction on the PDF fragments in `fragmentTests`.
-func _TestTextExtractionFragments(t *testing.T) {
+func TestTextExtractionFragments(t *testing.T) {
 	fragmentTests := []struct {
 		name     string
 		contents string
@@ -144,7 +144,7 @@ func _TestTextExtractionFragments(t *testing.T) {
 // TestTextExtractionFiles tests text extraction on a set of PDF files.
 // It checks for the existence of specified strings of words on specified pages.
 // We currently only check within lines as our line order is still improving.
-func _TestTextExtractionFiles(t *testing.T) {
+func TestTextExtractionFiles(t *testing.T) {
 	if len(corpusFolder) == 0 && !forceTest {
 		t.Log("Corpus folder not set - skipping")
 		return
@@ -156,7 +156,7 @@ func _TestTextExtractionFiles(t *testing.T) {
 }
 
 // TestTextLocations tests locations of text marks.
-func _TestTextLocations(t *testing.T) {
+func TestTextLocations(t *testing.T) {
 	if len(corpusFolder) == 0 && !forceTest {
 		t.Log("Corpus folder not set - skipping")
 		return
@@ -169,7 +169,7 @@ func _TestTextLocations(t *testing.T) {
 
 // TestTermMarksFiles stress tests testTermMarksMulti() by running it on all files in the corpus.
 // It can take several minutes to run.
-func _TestTermMarksFiles(t *testing.T) {
+func TestTermMarksFiles(t *testing.T) {
 	if !doStress {
 		t.Skip("skipping stress test")
 	}

--- a/extractor/text_test.go
+++ b/extractor/text_test.go
@@ -201,52 +201,25 @@ func TestTextSort(t *testing.T) {
 		textMark{orientedStart: transform.Point{X: 300, Y: 5}, text: "22"},
 	}
 
-	// Copy marks0 to PageText and sort them. This should preserve order of marks.
+	// marks is a copy of marks0 with its order scrambled.
 	marks := make([]textMark, len(marks0))
 	copy(marks, marks0)
 	sort.Slice(marks, func(i, j int) bool {
 		ti, tj := marks[i], marks[j]
-		if ti.orient != tj.orient {
-			return ti.orient > tj.orient
-		}
 		if ti.orientedStart.X != tj.orientedStart.X {
 			return ti.orientedStart.X > tj.orientedStart.X
 		}
+		if ti.orient != tj.orient {
+			return ti.orient > tj.orient
+		}
 		return ti.orientedStart.Y < tj.orientedStart.Y
-	   })
+	})
+
+	// Copy marks to PageText and sort them. This should give the same order as marks0.
 	pt := PageText{marks: marks}
 	pt.sortPosition(15)
 
-	fmt.Println("==================================== Presorted")
-	for i, m:= range marks {
-		fmt.Printf("%3d: %v\n", i, m)
-	}
-	// Check that marks order hasn't changed.
-	for i, m0 := range marks0 {
-		m := pt.marks[i]
-		if m.orientedStart.X != m0.orientedStart.X || m.orientedStart.Y != m0.orientedStart.Y {
-			t.Fatalf("i=%d m=%v != m0=%v", i, m, m0)
-		}
-	}
-
-	sort.Slice(marks, func(i, j int) bool {
-		ti, tj := marks[i], marks[j]
-		if ti.orient != tj.orient {
-			return ti.orient > tj.orient
-		}
-		if ti.orientedStart.X != tj.orientedStart.X {
-			return ti.orientedStart.X > tj.orientedStart.X
-		}
-		return ti.orientedStart.Y < tj.orientedStart.Y
-	   })
-	pt = PageText{marks: marks}
-	pt.sortPositionGus(15)
-
-	fmt.Println("==================================== Single sort")
-	for i, m:= range marks {
-		fmt.Printf("%3d: %v\n", i, m)
-	}
-	// Check that marks order hasn't changed.
+	// Check that marks order is the same as marks0.
 	for i, m0 := range marks0 {
 		m := pt.marks[i]
 		if m.orientedStart.X != m0.orientedStart.X || m.orientedStart.Y != m0.orientedStart.Y {

--- a/extractor/text_test.go
+++ b/extractor/text_test.go
@@ -139,7 +139,6 @@ func TestTextExtractionFragments(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 // TestTextExtractionFiles tests text extraction on a set of PDF files.
@@ -341,9 +340,6 @@ func testExtractFileOptions(t *testing.T, filename string, pageTerms map[int][]s
 			t.Fatalf("%q doesn't have page %d", filepath, pageNum)
 		}
 		actualText = norm.NFKC.String(actualText)
-		// fmt.Println("#################### $$ ####################")
-		// fmt.Println(actualText)
-		// fmt.Println("#################### @@ ####################")
 		if !containsTerms(t, expectedTerms, actualText) {
 			t.Fatalf("Text mismatch filepath=%q page=%d", filepath, pageNum)
 		}

--- a/extractor/text_test.go
+++ b/extractor/text_test.go
@@ -195,18 +195,19 @@ func TestTextSort(t *testing.T) {
 		textMark{orientedStart: transform.Point{X: 200, Y: 40}},
 		textMark{orientedStart: transform.Point{X: 300, Y: 50}},
 
-		// y difference > tol => sorts by X descending for approx same Y, different from previous Y
+		// y difference < tol => sorts by X descending for approx same Y, different from previous Y
 		textMark{orientedStart: transform.Point{X: 100, Y: 3}},
 		textMark{orientedStart: transform.Point{X: 200, Y: 4}},
 		textMark{orientedStart: transform.Point{X: 300, Y: 5}},
 	}
 
+	// Copy marks0 to PageText and sort them. This should preserve order of marks.
 	marks := make([]textMark, len(marks0))
 	copy(marks, marks0)
-
 	pt := PageText{marks: marks}
 	pt.sortPosition(15)
 
+	// Check that marks order hasn't changed.
 	for i, m0 := range marks0 {
 		m := pt.marks[i]
 		if m.orientedStart.X != m0.orientedStart.X || m.orientedStart.Y != m0.orientedStart.Y {


### PR DESCRIPTION
This is a fix for https://github.com/unidoc/unipdf/issues/152

The sort order is now deterministic and the ordering is explained in the source code.

A test case shows how the sorting works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unipdf/153)
<!-- Reviewable:end -->
