### PR TITLE
Remove examples link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ creating and reading, processing PDF files. The library is written and supported
 - CCITTFaxDecode decoding and encoding support
 - JBIG2 decoding support
 
-Multiple examples are provided in our example repository https://github.com/unidoc/unidoc-examples
-as well as [documented examples](https://unidoc.io/examples) on our website.
+Multiple examples are provided in our example repository https://github.com/unidoc/unidoc-examples.
 
 Contact us if you need any specific examples.
 


### PR DESCRIPTION
Seems that /examples was removed from website.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unipdf/185)
<!-- Reviewable:end -->
