### PR TITLE
Preserve TOC line components style properties when setting links

### DIFF
--- a/creator/creator_test.go
+++ b/creator/creator_test.go
@@ -822,7 +822,7 @@ func TestSubchaptersSimple(t *testing.T) {
 	c.AddTOC = true
 
 	lineStyle := c.NewTextStyle()
-	lineStyle.Font = model.NewStandard14FontMustCompile(model.HelveticaBoldName)
+	lineStyle.Font = model.NewStandard14FontMustCompile(model.HelveticaName)
 
 	toc := c.TOC()
 	toc.SetLineStyle(lineStyle)
@@ -898,9 +898,6 @@ func TestSubchaptersSimple(t *testing.T) {
 		toc.SetHeading("Table of Contents", style)
 
 		// Set style of TOC lines just before render.
-		lineStyle := c.NewTextStyle()
-		lineStyle.FontSize = 14
-
 		helveticaBold := model.NewStandard14FontMustCompile(model.HelveticaBoldName)
 
 		lines := toc.Lines()
@@ -923,7 +920,6 @@ func TestSubchapters(t *testing.T) {
 
 	lineStyle := c.NewTextStyle()
 	lineStyle.Font = model.NewStandard14FontMustCompile(model.HelveticaName)
-	lineStyle.FontSize = 14
 	lineStyle.Color = ColorRGBFromArithmetic(0.5, 0.5, 0.5)
 
 	toc := c.TOC()

--- a/creator/toc_line.go
+++ b/creator/toc_line.go
@@ -155,7 +155,12 @@ func (tl *TOCLine) SetLink(page int64, x, y float64) {
 	tl.linkY = y
 	tl.linkPage = page
 
-	tl.SetStyle(tl.sp.defaultLinkStyle)
+	// Set the color of the line components to the default link color.
+	linkColor := tl.sp.defaultLinkStyle.Color
+	tl.Number.Style.Color = linkColor
+	tl.Title.Style.Color = linkColor
+	tl.Separator.Style.Color = linkColor
+	tl.Page.Style.Color = linkColor
 }
 
 // getLineLink returns a new annotation if the line has a link set.


### PR DESCRIPTION
Related to #193

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unipdf/202)
<!-- Reviewable:end -->
