### PR TITLE
Use utf-16 encoding for serializing outline item titles

### DIFF
--- a/model/outline.go
+++ b/model/outline.go
@@ -151,7 +151,7 @@ func (oi *OutlineItem) Items() []*OutlineItem {
 func (oi *OutlineItem) ToPdfOutlineItem() (*PdfOutlineItem, int64) {
 	// Create outline item.
 	currItem := NewPdfOutlineItem()
-	currItem.Title = core.MakeString(oi.Title)
+	currItem.Title = core.MakeEncodedString(oi.Title, true)
 	currItem.Dest = oi.Dest.ToPdfObject()
 
 	// Create outline items.


### PR DESCRIPTION
Addresses comment on issue #193

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unipdf/223)
<!-- Reviewable:end -->
