### PR TITLE
Follow object indirections in PdfPage.GetMediaBox

### DIFF
--- a/model/page.go
+++ b/model/page.go
@@ -386,7 +386,7 @@ func (p *PdfPage) GetMediaBox() (*PdfRectangle, error) {
 		}
 
 		if obj := dict.Get("MediaBox"); obj != nil {
-			arr, ok := obj.(*core.PdfObjectArray)
+			arr, ok := core.GetArray(obj)
 			if !ok {
 				return nil, errors.New("invalid media box")
 			}


### PR DESCRIPTION
This change fixes resolving of the "media box" when the object is of type *PdfIndirectObject.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unipdf/231)
<!-- Reviewable:end -->
