### PR TITLE
Ignore optional inline image field parameters

### DIFF
--- a/contentstream/inline-image.go
+++ b/contentstream/inline-image.go
@@ -361,6 +361,8 @@ func (csp *ContentStreamParser) ParseInlineImage() (*ContentStreamInlineImage, e
 				im.Interpolate = valueObj
 			case "W", "Width":
 				im.Width = valueObj
+			case "Length", "Subtype", "Type":
+				common.Log.Debug("Ignoring inline parameter %s", *param)
 			default:
 				return nil, fmt.Errorf("unknown inline image parameter %s", *param)
 			}


### PR DESCRIPTION
Addresses #248 .

According to the PDF reference:
```
From 8.9.7 "Inline Images" p. 223 (PDF32000_2008):
The key-value pairs appearing between the BI and ID operators are analogous to those in the dictionary
portion of an image XObject (though the syntax is different).
Table 93 shows the entries that are valid for an inline image, all of which shall have the same meanings
as in a stream dictionary (see Table 5) or an image dictionary (see Table 89).
Entries other than those listed shall be ignored; in particular, the Type, Subtype, and Length
entries normally found in a stream or image dictionary are unnecessary.
```

so this PR allows the "unnecessary" Type, Subtype and Length rather than resulting in an error.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unipdf/247)
<!-- Reviewable:end -->
