### PR TITLE
Add whitespace tolerance when searching for inline image EI operand

### DIFF
--- a/contentstream/inline-image.go
+++ b/contentstream/inline-image.go
@@ -411,6 +411,12 @@ func (csp *ContentStreamParser) ParseInlineImage() (*ContentStreamInlineImage, e
 							skipBytes = []byte{}
 							skipBytes = append(skipBytes, c)
 							state = 1
+						} else if c == 'E' {
+							// Allow cases where EI is not preceded by whitespace.
+							// The extra parsing after EI<ws> should be sufficient
+							// in order to decide if the image stream ended.
+							skipBytes = append(skipBytes, c)
+							state = 2
 						} else {
 							im.stream = append(im.stream, c)
 						}


### PR DESCRIPTION
Addresses #245

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unipdf/252)
<!-- Reviewable:end -->
