### PR TITLE
Write out multi-encoder filters correctly

### DIFF
--- a/core/encoding.go
+++ b/core/encoding.go
@@ -2372,7 +2372,12 @@ func (enc *MultiEncoder) AddEncoder(encoder StreamEncoder) {
 // MakeStreamDict makes a new instance of an encoding dictionary for a stream object.
 func (enc *MultiEncoder) MakeStreamDict() *PdfObjectDictionary {
 	dict := MakeDict()
-	dict.Set("Filter", MakeName(enc.GetFilterName()))
+
+	names := make([]PdfObject, len(enc.encoders))
+	for i, e := range enc.encoders {
+		names[i] = MakeName(e.GetFilterName())
+	}
+	dict.Set("Filter", MakeArray(names...))
 
 	// Pass all values from children, except Filter and DecodeParms.
 	for _, encoder := range enc.encoders {


### PR DESCRIPTION
Fix for #279
Replaces  #280 which was based on the wrong branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unipdf/281)
<!-- Reviewable:end -->
