### PR TITLE
Add NewCompositePdfFontFromTTF to load composite TTF from memory

### DIFF
--- a/model/font_composite.go
+++ b/model/font_composite.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"sort"
 
@@ -569,17 +570,27 @@ func parseCIDFontWidthsArray(w core.PdfObject) (map[textencoding.CharCode]float6
 
 // NewCompositePdfFontFromTTFFile loads a composite font from a TTF font file. Composite fonts can
 // be used to represent unicode fonts which can have multi-byte character codes, representing a wide
-// range of values.
+// range of values. They are often used for symbolic languages, including Chinese, Japanese and Korean.
 // It is represented by a Type0 Font with an underlying CIDFontType2 and an Identity-H encoding map.
 // TODO: May be extended in the future to support a larger variety of CMaps and vertical fonts.
+// NOTE: For simple fonts, use NewPdfFontFromTTFFile.
 func NewCompositePdfFontFromTTFFile(filePath string) (*PdfFont, error) {
-	// Load the truetype font data.
 	ttfBytes, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		common.Log.Debug("ERROR: while reading ttf font: %v", err)
 		return nil, err
 	}
-	ttf, err := fonts.TtfParse(bytes.NewReader(ttfBytes))
+	return NewCompositePdfFontFromTTF(bytes.NewReader(ttfBytes))
+}
+
+// NewCompositePdfFontFromTTF loads a composite TTF font. Composite fonts can
+// be used to represent unicode fonts which can have multi-byte character codes, representing a wide
+// range of values. They are often used for symbolic languages, including Chinese, Japanese and Korean.
+// It is represented by a Type0 Font with an underlying CIDFontType2 and an Identity-H encoding map.
+// TODO: May be extended in the future to support a larger variety of CMaps and vertical fonts.
+// NOTE: For simple fonts, use NewPdfFontFromTTF.
+func NewCompositePdfFontFromTTF(rs io.ReadSeeker) (*PdfFont, error) {
+	ttf, err := fonts.TtfParse(rs)
 	if err != nil {
 		common.Log.Debug("ERROR: while loading ttf font: %v", err)
 		return nil, err

--- a/model/font_simple.go
+++ b/model/font_simple.go
@@ -385,6 +385,7 @@ func (font *pdfFontSimple) ToPdfObject() core.PdfObject {
 // NewPdfFontFromTTFFile loads a TTF font file and returns a PdfFont type
 // that can be used in text styling functions.
 // Uses a WinAnsiTextEncoder and loads only character codes 32-255.
+// NOTE: For composite fonts such as used in symbolic languages, use NewCompositePdfFontFromTTFFile.
 func NewPdfFontFromTTFFile(filePath string) (*PdfFont, error) {
 	f, err := os.Open(filePath)
 	if err != nil {
@@ -399,6 +400,7 @@ func NewPdfFontFromTTFFile(filePath string) (*PdfFont, error) {
 // NewPdfFontFromTTF loads a TTF font and returns a PdfFont type that can be
 // used in text styling functions.
 // Uses a WinAnsiTextEncoder and loads only character codes 32-255.
+// NOTE: For composite fonts such as used in symbolic languages, use NewCompositePdfFontFromTTF.
 func NewPdfFontFromTTF(r io.ReadSeeker) (*PdfFont, error) {
 	const minCode = textencoding.CharCode(32)
 	const maxCode = textencoding.CharCode(255)


### PR DESCRIPTION
Refactor the existing functionality to enable loading from stream rather than just file.  More flexible.

Clarified documentation a bit and added a note regarding composite fonts to the simple TTF font loading functions NewPdfFontFromTTF.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unipdf/319)
<!-- Reviewable:end -->
