### PR TITLE
Account for inverted annotation rects when calculating appearance bounds

### DIFF
--- a/annotator/field_appearance.go
+++ b/annotator/field_appearance.go
@@ -168,16 +168,12 @@ func genFieldTextAppearance(wa *model.PdfAnnotationWidget, ftxt *model.PdfFieldT
 	if !ok {
 		return nil, errors.New("invalid Rect")
 	}
-	rect, err := array.ToFloat64Array()
+	rect, err := model.NewPdfRectangle(*array)
 	if err != nil {
 		return nil, err
 	}
-	if len(rect) != 4 {
-		return nil, errors.New("len(Rect) != 4")
-	}
-
-	width := rect[2] - rect[0]
-	height := rect[3] - rect[1]
+	width := rect.Width()
+	height := rect.Height()
 
 	if mkDict, has := core.GetDict(wa.MK); has {
 		bsDict, _ := core.GetDict(wa.BS)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unipdf/357)
<!-- Reviewable:end -->
