### PR TITLE
Add configurable font fallback options for form fields

### DIFF
--- a/annotator/field_appearance.go
+++ b/annotator/field_appearance.go
@@ -218,8 +218,7 @@ func genFieldTextAppearance(wa *model.PdfAnnotationWidget, ftxt *model.PdfFieldT
 	if err != nil {
 		return nil, err
 	}
-	width := rect.Width()
-	height := rect.Height()
+	width, height := rect.Width(), rect.Height()
 
 	var rotation float64
 	if mkDict, has := core.GetDict(wa.MK); has {
@@ -518,8 +517,7 @@ func genFieldTextCombAppearance(wa *model.PdfAnnotationWidget, ftxt *model.PdfFi
 	if err != nil {
 		return nil, err
 	}
-	width := rect.Width()
-	height := rect.Height()
+	width, height := rect.Width(), rect.Height()
 
 	if mkDict, has := core.GetDict(wa.MK); has {
 		bsDict, _ := core.GetDict(wa.BS)
@@ -704,8 +702,6 @@ func genFieldTextCombAppearance(wa *model.PdfAnnotationWidget, ftxt *model.PdfFi
 // genFieldCheckboxAppearance generates an appearance dictionary for a widget annotation `wa` referenced by
 // a button field `fbtn` with form resources `dr` (DR).
 func genFieldCheckboxAppearance(wa *model.PdfAnnotationWidget, fbtn *model.PdfFieldButton, dr *model.PdfPageResources, style AppearanceStyle) (*core.PdfObjectDictionary, error) {
-	// TODO(dennwc): unused parameters
-
 	// Get bounding Rect.
 	array, ok := core.GetArray(wa.Rect)
 	if !ok {
@@ -715,8 +711,7 @@ func genFieldCheckboxAppearance(wa *model.PdfAnnotationWidget, fbtn *model.PdfFi
 	if err != nil {
 		return nil, err
 	}
-	width := rect.Width()
-	height := rect.Height()
+	width, height := rect.Width(), rect.Height()
 
 	common.Log.Debug("Checkbox, wa BS: %v", wa.BS)
 
@@ -818,8 +813,7 @@ func genFieldComboboxAppearance(form *model.PdfAcroForm, wa *model.PdfAnnotation
 	if err != nil {
 		return nil, err
 	}
-	width := rect.Width()
-	height := rect.Height()
+	width, height := rect.Width(), rect.Height()
 
 	common.Log.Debug("Choice, wa BS: %v", wa.BS)
 

--- a/annotator/field_appearance.go
+++ b/annotator/field_appearance.go
@@ -277,7 +277,7 @@ func genFieldTextAppearance(wa *model.PdfAnnotationWidget, ftxt *model.PdfFieldT
 	cc.Add_BT()
 
 	// Process DA operands.
-	apFont, err := style.processDA(ftxt.PdfField, daOps, dr, cc)
+	apFont, err := style.processDA(ftxt.PdfField, daOps, dr, resources, cc)
 	if err != nil {
 		return nil, err
 	}
@@ -288,11 +288,6 @@ func genFieldTextAppearance(wa *model.PdfAnnotationWidget, ftxt *model.PdfFieldT
 	autosize := fontsize == 0
 	if autosize {
 		fontsize = height * style.AutoFontSizeFraction
-	}
-
-	// Add appearance font to resources.
-	if !resources.HasFontByName(*fontname) {
-		resources.SetFontByName(*fontname, font.ToPdfObject())
 	}
 
 	encoder := font.Encoder()
@@ -560,7 +555,7 @@ func genFieldTextCombAppearance(wa *model.PdfAnnotationWidget, ftxt *model.PdfFi
 	cc.Add_BT()
 
 	// Process DA operands.
-	apFont, err := style.processDA(ftxt.PdfField, daOps, dr, cc)
+	apFont, err := style.processDA(ftxt.PdfField, daOps, dr, resources, cc)
 	if err != nil {
 		return nil, err
 	}
@@ -571,11 +566,6 @@ func genFieldTextCombAppearance(wa *model.PdfAnnotationWidget, ftxt *model.PdfFi
 	autosize := fontsize == 0
 	if autosize {
 		fontsize = height * style.AutoFontSizeFraction
-	}
-
-	// Add appearance font to resources.
-	if !resources.HasFontByName(*fontname) {
-		resources.SetFontByName(*fontname, font.ToPdfObject())
 	}
 
 	encoder := font.Encoder()
@@ -883,7 +873,7 @@ func makeComboboxTextXObjForm(field *model.PdfField, width, height float64,
 	cc.Add_BT()
 
 	// Process DA operands.
-	apFont, err := style.processDA(field, daOps, dr, cc)
+	apFont, err := style.processDA(field, daOps, dr, resources, cc)
 	if err != nil {
 		return nil, err
 	}
@@ -894,11 +884,6 @@ func makeComboboxTextXObjForm(field *model.PdfField, width, height float64,
 	autosize := fontsize == 0
 	if autosize {
 		fontsize = height * style.AutoFontSizeFraction
-	}
-
-	// Add appearance font to resources.
-	if !resources.HasFontByName(*fontname) {
-		resources.SetFontByName(*fontname, font.ToPdfObject())
 	}
 
 	encoder := font.Encoder()
@@ -1085,7 +1070,7 @@ func (style *AppearanceStyle) applyAppearanceCharacteristics(mkDict *core.PdfObj
 // in the default appearance. The method returns the font to be used when
 // generating the appearance of the field.
 func (style *AppearanceStyle) processDA(field *model.PdfField,
-	daOps *contentstream.ContentStreamOperations, dr *model.PdfPageResources,
+	daOps *contentstream.ContentStreamOperations, dr, resources *model.PdfPageResources,
 	cc *contentstream.ContentCreator) (*AppearanceFont, error) {
 	// Check for fallback fonts.
 	var fallbackFont *AppearanceFont
@@ -1157,9 +1142,13 @@ func (style *AppearanceStyle) processDA(field *model.PdfField,
 	}
 
 	// Add appearance font to the form resources (DR).
-	fontNameObj := *core.MakeName(apFont.Name)
-	if dr != nil && !dr.HasFontByName(fontNameObj) {
-		dr.SetFontByName(fontNameObj, apFont.Font.ToPdfObject())
+	apFontName := *core.MakeName(apFont.Name)
+	apFontObj := apFont.Font.ToPdfObject()
+	if dr != nil && !dr.HasFontByName(apFontName) {
+		dr.SetFontByName(apFontName, apFontObj)
+	}
+	if resources != nil && !resources.HasFontByName(apFontName) {
+		resources.SetFontByName(apFontName, apFontObj)
 	}
 
 	return apFont, nil

--- a/annotator/field_appearance.go
+++ b/annotator/field_appearance.go
@@ -283,13 +283,12 @@ func genFieldTextAppearance(wa *model.PdfAnnotationWidget, ftxt *model.PdfFieldT
 		return nil, err
 	}
 
-	fontsizeDef := height * style.AutoFontSizeFraction
 	font := apFont.Font
 	fontsize := apFont.Size
 	fontname := core.MakeName(apFont.Name)
 	autosize := fontsize == 0
 	if autosize {
-		fontsize = fontsizeDef
+		fontsize = height * style.AutoFontSizeFraction
 	}
 
 	// Add appearance font to resources.
@@ -568,13 +567,12 @@ func genFieldTextCombAppearance(wa *model.PdfAnnotationWidget, ftxt *model.PdfFi
 		return nil, err
 	}
 
-	fontsizeDef := height * style.AutoFontSizeFraction
 	font := apFont.Font
-	fontsize := apFont.Size
 	fontname := core.MakeName(apFont.Name)
+	fontsize := apFont.Size
 	autosize := fontsize == 0
 	if autosize {
-		fontsize = fontsizeDef
+		fontsize = height * style.AutoFontSizeFraction
 	}
 
 	// Add appearance font to resources.
@@ -896,13 +894,12 @@ func makeComboboxTextXObjForm(field *model.PdfField, width, height float64,
 		return nil, err
 	}
 
-	fontsizeDef := height * style.AutoFontSizeFraction
 	font := apFont.Font
 	fontsize := apFont.Size
 	fontname := core.MakeName(apFont.Name)
 	autosize := fontsize == 0
 	if autosize {
-		fontsize = fontsizeDef
+		fontsize = height * style.AutoFontSizeFraction
 	}
 
 	// Add appearance font to resources.
@@ -1138,7 +1135,7 @@ func (style *AppearanceStyle) processDA(field *model.PdfField,
 	}
 
 	apFont := fallbackFont
-	if !forceReplace || fallbackFont == nil {
+	if !forceReplace || apFont == nil {
 		// Check if font name was found in the DA stream and search it in the resources.
 		if dr != nil && fontName != "" {
 			if obj, ok := dr.GetFontByName(*core.MakeName(fontName)); ok {


### PR DESCRIPTION
- Add global font fallback option for fields with invalid or not specified fonts in their DA stream
- Add font fallback per form field option
- Add option to force font replacement when filling/flattening form fields

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unipdf/368)
<!-- Reviewable:end -->
