### PR TITLE
Add cached Stream method for CMap objects

### DIFF
--- a/model/font.go
+++ b/model/font.go
@@ -707,10 +707,9 @@ func (base fontCommon) asPdfObjectDictionary(subtype string) *core.PdfObjectDict
 	if base.toUnicode != nil {
 		d.Set("ToUnicode", base.toUnicode)
 	} else if base.toUnicodeCmap != nil {
-		data := base.toUnicodeCmap.Bytes()
-		o, err := core.MakeStream(data, core.NewFlateEncoder())
+		o, err := base.toUnicodeCmap.Stream()
 		if err != nil {
-			common.Log.Debug("MakeStream failed. err=%v", err)
+			common.Log.Debug("WARN: could not get CMap stream. err=%v", err)
 		} else {
 			d.Set("ToUnicode", o)
 		}


### PR DESCRIPTION
Related to https://github.com/unidoc/unipdf/issues/378 and https://github.com/unidoc/unipdf/issues/318.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unipdf/382)
<!-- Reviewable:end -->
